### PR TITLE
Fix Jellyfin 10.11.9 compatibility: replace IUserManager.Users with GetUsers()

### DIFF
--- a/Jellyfin.Plugin.LocalRecs.Tests/Jellyfin.Plugin.LocalRecs.Tests.csproj
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Jellyfin.Plugin.LocalRecs.Tests.csproj
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jellyfin.Controller" Version="10.11.5" />
-        <PackageReference Include="Jellyfin.Database.Implementations" Version="10.11.5" />
-        <PackageReference Include="Jellyfin.Model" Version="10.11.5" />
+        <PackageReference Include="Jellyfin.Controller" Version="10.11.9" />
+        <PackageReference Include="Jellyfin.Database.Implementations" Version="10.11.9" />
+        <PackageReference Include="Jellyfin.Model" Version="10.11.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/Jellyfin.Plugin.LocalRecs/Api/LibraryPathsController.cs
+++ b/Jellyfin.Plugin.LocalRecs/Api/LibraryPathsController.cs
@@ -53,7 +53,7 @@ namespace Jellyfin.Plugin.LocalRecs.Api
         {
             try
             {
-                var users = _userManager.Users.ToList();
+                var users = _userManager.GetUsers().ToList();
                 var paths = new List<UserLibraryPathInfo>();
 
                 foreach (var user in users)

--- a/Jellyfin.Plugin.LocalRecs/Jellyfin.Plugin.LocalRecs.csproj
+++ b/Jellyfin.Plugin.LocalRecs/Jellyfin.Plugin.LocalRecs.csproj
@@ -16,10 +16,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jellyfin.Controller" Version="10.11.5">
+        <PackageReference Include="Jellyfin.Controller" Version="10.11.9">
             <ExcludeAssets>runtime</ExcludeAssets>
         </PackageReference>
-        <PackageReference Include="Jellyfin.Model" Version="10.11.5">
+        <PackageReference Include="Jellyfin.Model" Version="10.11.9">
             <ExcludeAssets>runtime</ExcludeAssets>
         </PackageReference>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />

--- a/Jellyfin.Plugin.LocalRecs/ScheduledTasks/BenchmarkTask.cs
+++ b/Jellyfin.Plugin.LocalRecs/ScheduledTasks/BenchmarkTask.cs
@@ -174,7 +174,7 @@ namespace Jellyfin.Plugin.LocalRecs.ScheduledTasks
                 results.AppendLine("4. User Profile Generation");
                 results.AppendLine("   " + new string('-', 76));
 
-                var users = _userManager.Users.ToList();
+                var users = _userManager.GetUsers().ToList();
                 var metadata = library.ToDictionary(m => m.Id);
 
                 // Use the embeddings directly if it's already a dictionary, otherwise convert

--- a/Jellyfin.Plugin.LocalRecs/ScheduledTasks/RecommendationRefreshTask.cs
+++ b/Jellyfin.Plugin.LocalRecs/ScheduledTasks/RecommendationRefreshTask.cs
@@ -68,7 +68,7 @@ namespace Jellyfin.Plugin.LocalRecs.ScheduledTasks
                 // Step 1: Get all users (5% progress)
                 progress?.Report(0);
                 cancellationToken.ThrowIfCancellationRequested();
-                var users = _userManager.Users.ToList();
+                var users = _userManager.GetUsers().ToList();
                 _logger.LogInformation("Generating recommendations for {UserCount} users", users.Count);
                 progress?.Report(5);
 

--- a/Jellyfin.Plugin.LocalRecs/VirtualLibrary/PlayStatusSyncService.cs
+++ b/Jellyfin.Plugin.LocalRecs/VirtualLibrary/PlayStatusSyncService.cs
@@ -241,7 +241,7 @@ namespace Jellyfin.Plugin.LocalRecs.VirtualLibrary
 
             _logger.LogInformation("Syncing play status from source library for all users");
 
-            foreach (var user in _userManager.Users)
+            foreach (var user in _userManager.GetUsers())
             {
                 try
                 {

--- a/Jellyfin.Plugin.LocalRecs/VirtualLibrary/VirtualLibraryInitializer.cs
+++ b/Jellyfin.Plugin.LocalRecs/VirtualLibrary/VirtualLibraryInitializer.cs
@@ -108,7 +108,7 @@ namespace Jellyfin.Plugin.LocalRecs.VirtualLibrary
             }
 
             // Get users once to avoid multiple enumerations
-            var users = _userManager.Users.ToList();
+            var users = _userManager.GetUsers().ToList();
             var successCount = 0;
 
             foreach (var user in users)
@@ -133,7 +133,7 @@ namespace Jellyfin.Plugin.LocalRecs.VirtualLibrary
 
         private void LogSetupInstructions()
         {
-            var users = _userManager.Users.ToList();
+            var users = _userManager.GetUsers().ToList();
 
             if (users.Count == 0)
             {


### PR DESCRIPTION
## What broke and why

Jellyfin 10.11.9 removed the \`IUserManager.Users\` property as part of PR [#15368 — Fix UserManager after EFcore refactor](https://github.com/jellyfin/jellyfin/pull/15368).

\`IUserManager.Users\` was an in-memory cached list of all users that UserManager kept in sync. The EFCore migration introduced concurrency issues (stale cached entities, \`DbUpdateConcurrencyException\`) so the cache was removed entirely. The property had nothing to back it and was dropped, replaced by \`IUserManager.GetUsers()\` which queries the database on each call.

On any server running Jellyfin 10.11.9+, every call site that accesses \`.Users\` throws at runtime:

\`\`\`
System.MissingMethodException: Method not found:
  'IEnumerable<User> IUserManager.get_Users()'
\`\`\`

This crashes the recommendation refresh task, the benchmark task, the setup API endpoint, the virtual library initializer, and the play status sync service — the plugin is completely non-functional on 10.11.9.

## Changes

Replace all six \`_userManager.Users\` call sites with \`_userManager.GetUsers()\` and update the Jellyfin SDK references from \`10.11.5\` to \`10.11.9\`:

- \`ScheduledTasks/RecommendationRefreshTask.cs\`
- \`ScheduledTasks/BenchmarkTask.cs\`
- \`Api/LibraryPathsController.cs\`
- \`VirtualLibrary/VirtualLibraryInitializer.cs\` (2 call sites)
- \`VirtualLibrary/PlayStatusSyncService.cs\`
- \`Jellyfin.Plugin.LocalRecs.csproj\`
- \`Jellyfin.Plugin.LocalRecs.Tests.csproj\`

## Breaking change / targetAbi

\`GetUsers()\` was introduced in 10.11.9 — it does not exist on 10.11.0–10.11.8. This fix is therefore **not backwards compatible**: a server on 10.11.8 or earlier would get the same \`MissingMethodException\` on \`GetUsers()\`.

The correct way to handle this in Jellyfin's plugin catalogue is to update \`targetAbi\` to \`10.11.9.0\` for any release built from this fix. Jellyfin will then refuse to offer the updated plugin to servers that can't run it, while leaving the existing 10.11.0-compatible release available to older servers.

## Test plan

- [ ] Build passes against Jellyfin 10.11.9 SDK
- [ ] Recommendation refresh task completes without \`MissingMethodException\` on 10.11.9
- [ ] Benchmark task completes without \`MissingMethodException\` on 10.11.9
- [ ] Setup tab loads library paths correctly on 10.11.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)