### PR TITLE
Fix SyncRecommendations_SymlinksArtworkFromSourceFolder test

### DIFF
--- a/Jellyfin.Plugin.LocalRecs.Tests/Unit/VirtualLibrary/VirtualLibraryManagerTests.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Unit/VirtualLibrary/VirtualLibraryManagerTests.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.LocalRecs.VirtualLibrary;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -214,8 +215,10 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Unit.VirtualLibrary
             _manager.EnsureUserDirectoriesExist(userId, "TestUser");
 
             // Drop artwork in source folder
-            File.WriteAllText(Path.Combine(_sourceMediaDir, "poster.jpg"), "fake poster");
-            File.WriteAllText(Path.Combine(_sourceMediaDir, "fanart.jpg"), "fake fanart");
+            var posterPath = Path.Combine(_sourceMediaDir, "poster.jpg");
+            var fanartPath = Path.Combine(_sourceMediaDir, "fanart.jpg");
+            File.WriteAllText(posterPath, "fake poster");
+            File.WriteAllText(fanartPath, "fake fanart");
 
             var movieId = Guid.NewGuid();
             var mockMovie = new Movie
@@ -223,7 +226,12 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Unit.VirtualLibrary
                 Id = movieId,
                 Name = "Art Movie",
                 Path = _sourceMediaFile,
-                ProductionYear = 2023
+                ProductionYear = 2023,
+                ImageInfos = new[]
+                {
+                    new ItemImageInfo { Type = ImageType.Primary, Path = posterPath },
+                    new ItemImageInfo { Type = ImageType.Backdrop, Path = fanartPath }
+                }
             };
 
             _mockLibraryManager.Setup(m => m.GetItemById(movieId)).Returns(mockMovie);


### PR DESCRIPTION
## Summary

Fixes `SyncRecommendations_SymlinksArtworkFromSourceFolder`, which fails in the current v0.6.0 test suite.

## Root cause

`VirtualLibraryManager.LinkItemArtwork()` finds artwork via:

```csharp
var posterPath = item.GetImagePath(ImageType.Primary, 0);
```

`GetImagePath()` reads from `item.ImageInfos` — Jellyfin's in-memory metadata cache populated by the library scanner with paths to artwork files on disk.

The test drops `poster.jpg` and `fanart.jpg` onto the filesystem and expects symlinks to appear, but the mock `Movie` has no `ImageInfos` set (defaults to `Array.Empty<ItemImageInfo>()`). So `GetImagePath()` returns `null`, no symlinks are created, and the assertion fails:

```
Expected File.Exists(Path.Combine(folder, "poster.jpg")) to be True, but found False.
```

## Fix

Populate `ImageInfos` on the mock `Movie` with `ItemImageInfo` entries pointing to the files written to disk:

```csharp
ImageInfos = new[]
{
    new ItemImageInfo { Type = ImageType.Primary, Path = posterPath },
    new ItemImageInfo { Type = ImageType.Backdrop, Path = fanartPath }
}
```

This reflects how a real Jellyfin item looks after library scanning — `ImageInfos` is always populated with source folder paths before the plugin sees the item. The production code is correct; the test setup was incomplete.

## Files changed

- `Jellyfin.Plugin.LocalRecs.Tests/Unit/VirtualLibrary/VirtualLibraryManagerTests.cs` — test only, no production code changes