### PR TITLE
Fix TV series recency: use most recent watched episode date for decay

### DIFF
--- a/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
@@ -145,23 +145,30 @@ namespace Jellyfin.Plugin.LocalRecs.Services
                     continue;
                 }
 
-                // For series, userData.Played is unreliable - it only becomes true when ALL
-                // episodes are watched. Instead, check for any watched episodes to include
-                // series the user has actually engaged with in the taste profile.
+                // For series, userData.Played is unreliable — it only becomes true when ALL
+                // episodes are watched. Use the most recently watched episode's date instead.
+                DateTime lastPlayedDate;
                 if (item is Series series)
                 {
-                    if (!HasAnyWatchedEpisodes(series, user))
+                    var seriesLastPlayed = GetLastWatchedEpisodeDate(series, user);
+                    if (seriesLastPlayed == null)
                     {
                         continue;
                     }
+
+                    lastPlayedDate = seriesLastPlayed.Value;
                 }
                 else if (!userData.Played)
                 {
                     // For movies, Played = true means the movie was completed.
                     continue;
                 }
+                else
+                {
+                    lastPlayedDate = userData.LastPlayedDate ?? DateTime.UtcNow;
+                }
 
-                var record = new WatchRecord(itemId, userId, userData.LastPlayedDate ?? DateTime.UtcNow)
+                var record = new WatchRecord(itemId, userId, lastPlayedDate)
                 {
                     IsFavorite = userData.IsFavorite,
                     PlayCount = userData.PlayCount > 0 ? userData.PlayCount : 1,
@@ -176,20 +183,28 @@ namespace Jellyfin.Plugin.LocalRecs.Services
         }
 
         /// <summary>
-        /// Checks if a series has any watched episodes.
+        /// Returns the most recent LastPlayedDate across watched episodes of a series,
+        /// or null if no episodes have been watched.
         /// </summary>
-        private bool HasAnyWatchedEpisodes(Series series, Jellyfin.Database.Implementations.Entities.User user)
+        private DateTime? GetLastWatchedEpisodeDate(Series series, Jellyfin.Database.Implementations.Entities.User user)
         {
-            var watchedEpisodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            var result = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 AncestorIds = new[] { series.Id },
                 IsPlayed = true,
-                Limit = 1,
-                Recursive = true
+                Recursive = true,
+                OrderBy = new[] { (ItemSortBy.DatePlayed, Jellyfin.Database.Implementations.Enums.SortOrder.Descending) },
+                Limit = 1
             });
 
-            return watchedEpisodes.Count > 0;
+            if (result.Count == 0)
+            {
+                return null;
+            }
+
+            var epData = _userDataManager.GetUserData(user, result[0]);
+            return epData?.LastPlayedDate ?? DateTime.UtcNow;
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

TV series in the taste profile were always treated as if watched today, regardless of when they were actually last viewed.

**Root cause:** Jellyfin only sets `LastPlayedDate` on episode items — the series-level `UserItemData.LastPlayedDate` is always `null`. The previous code fell back to `DateTime.UtcNow` for all series:

```csharp
// series date was never set by Jellyfin → always null → always today
var record = new WatchRecord(itemId, userId, userData.LastPlayedDate ?? DateTime.UtcNow)
```

**Impact:** Every watched TV series received `daysSince = 0` → `decay = 1.0` (maximum weight), inflating TV content influence on the taste vector independently of actual recency. A series finished two years ago competed equally with a movie watched yesterday.

## Fix

Replace `HasAnyWatchedEpisodes` (bool, no date) with `GetLastWatchedEpisodeDate` (DateTime?) which queries the most recently played episode directly:

```csharp
var result = _libraryManager.GetItemList(new InternalItemsQuery(user)
{
    IncludeItemTypes = new[] { BaseItemKind.Episode },
    AncestorIds = new[] { series.Id },
    IsPlayed = true,
    Recursive = true,
    OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending) },
    Limit = 1
});
```

- Returns `null` if no episodes watched → same exclude-series behaviour as before
- Returns the actual most recent episode date → decay now reflects real recency
- `OrderBy + Limit 1` keeps the same single-query cost as the original existence check

## Test plan

- [ ] Watch a TV series, confirm it shows correct days-since in the diagnostic log rather than `0d ago`
- [ ] Series with no watched episodes are still excluded from the taste profile
- [ ] Movie recency and weighting unaffected