### PR TITLE
Replace rewatch boost with recent-watch emphasis (decay²)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,7 +185,7 @@ The plugin follows a **layered architecture** with clear separation of concerns:
 
 **Weighting Factors:**
 - **Favorites:** 2.0x boost (configurable)
-- **Rewatches:** 1.5x boost (configurable)
+- **Recent watch emphasis:** decay² amplification — `decay × (1 + recentWatchBoost × decay)` — disproportionately amplifies recently watched items without relying on unreliable play count data (default: 1.0, configurable)
 - **Recency decay:** Exponential decay with configurable half-life (default: 365 days)
 
 **Output:** Normalized user profile vector (same dimensionality as item embeddings)
@@ -489,7 +489,7 @@ All settings exposed via plugin configuration UI and stored in Jellyfin's plugin
 ### Key Settings
 - **Recommendation counts:** Movies and TV (default: 25 each)
 - **Update schedule:** Daily at 4:00 AM by default (customizable via Scheduled Tasks UI)
-- **Weighting factors:** Favorite boost (2x), rewatch boost (1.5x), recency decay half-life (365 days)
+- **Weighting factors:** Favorite boost (2x), recent watch emphasis (decay² amplification, default 1.0), recency decay half-life (365 days)
 - **Performance tuning:** Vocabulary limits for actors, directors, and tags
 - **Cold-start threshold:** Minimum watched items for personalization (default: 3)
 - **Series filtering:** Exclude abandoned series from recommendations (configurable threshold)

--- a/Jellyfin.Plugin.LocalRecs.Tests/Domain/UserProfileServiceTests.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Domain/UserProfileServiceTests.cs
@@ -46,7 +46,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Domain
             _config = new PluginConfiguration
             {
                 FavoriteBoost = 2.0,
-                RewatchBoost = 1.5,
+                RecentWatchBoost = 1.0,
                 RecencyDecayHalfLifeDays = 365.0,
                 MinWatchedItemsForPersonalization = 3
             };
@@ -128,41 +128,6 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Domain
             matrixSimilarity.Should().BeGreaterThan(inceptionSimilarity,
                 "favorite item should have more influence due to favorite boost of {0}",
                 _config.FavoriteBoost);
-        }
-
-        [Fact]
-        public void BuildUserProfile_WithRewatches_RewatchesGetHigherWeight()
-        {
-            // Arrange
-            var library = TestMediaLibrary.CreateTestMovies();
-            var godfather = library.First(m => m.Name == "The Godfather");
-            var toyStory = library.First(m => m.Name == "Toy Story");
-
-            var embeddings = CreateEmbeddings(library);
-            var metadata = library.ToDictionary(i => i.Id, i => i);
-
-            // Setup: Godfather watched 5 times, Toy Story watched once (same recency, not favorites)
-            SetupSpecificUserData(godfather, isFavorite: false, playCount: 5, daysAgo: 10);
-            SetupSpecificUserData(toyStory, isFavorite: false, playCount: 1, daysAgo: 10);
-
-            // Act
-            var profile = _service.BuildUserProfile(_testUserId, embeddings, _config);
-
-            // Assert
-            profile.Should().NotBeNull();
-            profile!.WatchedItemCount.Should().Be(2);
-
-            // Verify that the taste vector is more similar to the rewatched item
-            var godfatherSimilarity = Utilities.VectorMath.CosineSimilarity(
-                profile.TasteVector,
-                embeddings[godfather.Id].Vector);
-            var toyStorySimilarity = Utilities.VectorMath.CosineSimilarity(
-                profile.TasteVector,
-                embeddings[toyStory.Id].Vector);
-
-            // Godfather (rewatched 5x) should have higher influence on taste vector
-            godfatherSimilarity.Should().BeGreaterThan(toyStorySimilarity,
-                "rewatched item should have more influence due to rewatch boost");
         }
 
         [Fact]

--- a/Jellyfin.Plugin.LocalRecs.Tests/Integration/LiveServerIntegrationTests.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Integration/LiveServerIntegrationTests.cs
@@ -643,7 +643,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
             var config = new PluginConfiguration
             {
                 FavoriteBoost = 2.0,
-                RewatchBoost = 1.5,
+                RecentWatchBoost = 1.0,
                 RecencyDecayHalfLifeDays = 365.0
             };
 
@@ -709,13 +709,6 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
                 if (item.TryGetProperty("UserData", out var userDataForWeight))
                 {
                     bool isFavorite = userDataForWeight.TryGetProperty("IsFavorite", out var fav) && fav.GetBoolean();
-                    int playCount = userDataForWeight.TryGetProperty("PlayCount", out var pc) ? pc.GetInt32() : 1;
-                    
-                    // Ensure playCount is at least 1 for watched items (Jellyfin sometimes returns 0)
-                    if (playCount < 1)
-                    {
-                        playCount = 1;
-                    }
 
                     DateTime lastPlayed = DateTime.UtcNow;
                     if (userDataForWeight.TryGetProperty("LastPlayedDate", out var lpd))
@@ -727,7 +720,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
                     weight = (float)Utilities.WeightCalculator.ComputeCombinedWeight(
                         daysSince, config.RecencyDecayHalfLifeDays,
                         isFavorite, (float)config.FavoriteBoost,
-                        playCount, (float)config.RewatchBoost);
+                        (float)config.RecentWatchBoost);
                 }
 
                 weightedVectors.Add((embedding.Vector, weight));

--- a/Jellyfin.Plugin.LocalRecs.Tests/Integration/PipelineIntegrationTests.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Integration/PipelineIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
             _config = new PluginConfiguration
             {
                 FavoriteBoost = 2.0,
-                RewatchBoost = 1.5,
+                RecentWatchBoost = 1.0,
                 RecencyDecayHalfLifeDays = 365.0,
                 MinWatchedItemsForPersonalization = 3,
                 MovieRecommendationCount = 25,
@@ -534,7 +534,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
             var configWithZeroHalfLife = new PluginConfiguration
             {
                 FavoriteBoost = 2.0,
-                RewatchBoost = 1.5,
+                RecentWatchBoost = 1.0,
                 RecencyDecayHalfLifeDays = 0.0, // Invalid value!
                 MinWatchedItemsForPersonalization = 3
             };
@@ -569,7 +569,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
             var configWithSmallHalfLife = new PluginConfiguration
             {
                 FavoriteBoost = 2.0,
-                RewatchBoost = 1.5,
+                RecentWatchBoost = 1.0,
                 RecencyDecayHalfLifeDays = 0.001, // Very small but valid
                 MinWatchedItemsForPersonalization = 3
             };
@@ -616,8 +616,8 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Integration
 
             var configWithExtremeBoosts = new PluginConfiguration
             {
-                FavoriteBoost = 100.0,  // Extreme
-                RewatchBoost = 50.0,    // Extreme
+                FavoriteBoost = 100.0,     // Extreme
+                RecentWatchBoost = 50.0,   // Extreme
                 RecencyDecayHalfLifeDays = 1.0, // Very short
                 MinWatchedItemsForPersonalization = 3
             };

--- a/Jellyfin.Plugin.LocalRecs.Tests/Unit/WeightCalculatorTests.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Unit/WeightCalculatorTests.cs
@@ -88,82 +88,95 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Unit
         }
 
         [Fact]
-        public void ApplyRewatchBoost_SingleWatch_ReturnsBaseWeight()
+        public void ApplyRecentWatchBoost_ZeroBoost_ReturnsDecay()
         {
-            var result = WeightCalculator.ApplyRewatchBoost(baseWeight: 1.0f, playCount: 1, rewatchBase: 1.5f);
+            var result = WeightCalculator.ApplyRecentWatchBoost(decay: 0.5f, recentWatchBoost: 0.0f);
 
-            result.Should().Be(1.0f);
+            result.Should().BeApproximately(0.5f, 0.0001f);
         }
 
         [Fact]
-        public void ApplyRewatchBoost_MultipleWatches_AppliesLogarithmicBoost()
+        public void ApplyRecentWatchBoost_JustWatchedWithBoostOne_DoublesWeight()
         {
-            var result = WeightCalculator.ApplyRewatchBoost(baseWeight: 1.0f, playCount: 3, rewatchBase: 1.5f);
+            // decay=1 (just watched), boost=1 → 1 × (1 + 1×1) = 2
+            var result = WeightCalculator.ApplyRecentWatchBoost(decay: 1.0f, recentWatchBoost: 1.0f);
 
-            // log_1.5(3) ≈ 2.71, so boost = 1 + 2.71 = 3.71
-            result.Should().BeGreaterThan(1.0f);
-            result.Should().BeApproximately(3.71f, 0.1f);
+            result.Should().BeApproximately(2.0f, 0.0001f);
         }
 
         [Fact]
-        public void ApplyRewatchBoost_NegativeBaseWeight_ThrowsArgumentException()
+        public void ApplyRecentWatchBoost_OldItemsLessAmplified()
         {
-            Action act = () => WeightCalculator.ApplyRewatchBoost(baseWeight: -1.0f, playCount: 2, rewatchBase: 1.5f);
+            var recentResult = WeightCalculator.ApplyRecentWatchBoost(decay: 1.0f, recentWatchBoost: 1.0f);
+            var oldResult = WeightCalculator.ApplyRecentWatchBoost(decay: 0.5f, recentWatchBoost: 1.0f);
 
-            act.Should().Throw<ArgumentException>().WithParameterName("baseWeight");
+            recentResult.Should().BeGreaterThan(oldResult);
         }
 
         [Fact]
-        public void ApplyRewatchBoost_ZeroPlayCount_ThrowsArgumentException()
+        public void ApplyRecentWatchBoost_NegativeDecay_ThrowsArgumentException()
         {
-            Action act = () => WeightCalculator.ApplyRewatchBoost(baseWeight: 1.0f, playCount: 0, rewatchBase: 1.5f);
+            Action act = () => WeightCalculator.ApplyRecentWatchBoost(decay: -0.1f, recentWatchBoost: 1.0f);
 
-            act.Should().Throw<ArgumentException>().WithParameterName("playCount");
+            act.Should().Throw<ArgumentException>().WithParameterName("decay");
         }
 
         [Fact]
-        public void ApplyRewatchBoost_RewatchBaseOne_ThrowsArgumentException()
+        public void ApplyRecentWatchBoost_DecayAboveOne_ThrowsArgumentException()
         {
-            Action act = () => WeightCalculator.ApplyRewatchBoost(baseWeight: 1.0f, playCount: 2, rewatchBase: 1.0f);
+            Action act = () => WeightCalculator.ApplyRecentWatchBoost(decay: 1.1f, recentWatchBoost: 1.0f);
 
-            act.Should().Throw<ArgumentException>().WithParameterName("rewatchBase");
+            act.Should().Throw<ArgumentException>().WithParameterName("decay");
         }
 
         [Fact]
-        public void ApplyRewatchBoost_RewatchBaseLessThanOne_ThrowsArgumentException()
+        public void ApplyRecentWatchBoost_NegativeBoost_ThrowsArgumentException()
         {
-            Action act = () => WeightCalculator.ApplyRewatchBoost(baseWeight: 1.0f, playCount: 2, rewatchBase: 0.5f);
+            Action act = () => WeightCalculator.ApplyRecentWatchBoost(decay: 0.5f, recentWatchBoost: -1.0f);
 
-            act.Should().Throw<ArgumentException>().WithParameterName("rewatchBase");
+            act.Should().Throw<ArgumentException>().WithParameterName("recentWatchBoost");
         }
 
         [Fact]
-        public void ComputeCombinedWeight_AllFactors_ReturnsCompoundedWeight()
+        public void ComputeCombinedWeight_WithBoostAndFavorite_ReturnsCompoundedWeight()
         {
+            // decay = 0.5, boost: 0.5×(1+1×0.5)=0.75, favorite: 0.75×2=1.5
             var result = WeightCalculator.ComputeCombinedWeight(
                 daysSince: 365,
                 halfLifeDays: 365,
                 isFavorite: true,
                 favoriteBoost: 2.0f,
-                playCount: 2,
-                rewatchBase: 1.5f);
+                recentWatchBoost: 1.0f);
 
-            // decay = 0.5, favorite = 0.5 * 2 = 1.0, rewatch = 1.0 * (1 + log_1.5(2)) ≈ 1.0 * 2.71 ≈ 2.71
-            result.Should().BeGreaterThan(1.0f);
+            result.Should().BeApproximately(1.5f, 0.001f);
         }
 
         [Fact]
-        public void ComputeCombinedWeight_NotFavoriteSingleWatch_AppliesOnlyDecay()
+        public void ComputeCombinedWeight_ZeroBoostNotFavorite_AppliesOnlyDecaySquared()
         {
+            // decay=0.5, boost=0: 0.5×(1+0)=0.5
             var result = WeightCalculator.ComputeCombinedWeight(
                 daysSince: 365,
                 halfLifeDays: 365,
                 isFavorite: false,
                 favoriteBoost: 2.0f,
-                playCount: 1,
-                rewatchBase: 1.5f);
+                recentWatchBoost: 0.0f);
 
-            result.Should().BeApproximately(0.5f, 0.0001f); // Only decay applies
+            result.Should().BeApproximately(0.5f, 0.0001f);
+        }
+
+        [Fact]
+        public void ComputeCombinedWeight_JustWatchedWithBoost_AmplifiedWeight()
+        {
+            // daysSince=0 → decay=1, boost=1: 1×(1+1×1)=2
+            var result = WeightCalculator.ComputeCombinedWeight(
+                daysSince: 0,
+                halfLifeDays: 365,
+                isFavorite: false,
+                favoriteBoost: 2.0f,
+                recentWatchBoost: 1.0f);
+
+            result.Should().BeApproximately(2.0f, 0.0001f);
         }
 
     }

--- a/Jellyfin.Plugin.LocalRecs/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.LocalRecs/Configuration/PluginConfiguration.cs
@@ -16,7 +16,7 @@ namespace Jellyfin.Plugin.LocalRecs.Configuration
             MovieRecommendationCount = 25;
             TvRecommendationCount = 25;
             FavoriteBoost = 2.0;
-            RewatchBoost = 1.5;
+            RecentWatchBoost = 1.0;
             RecencyDecayHalfLifeDays = 365.0;
             MinWatchedItemsForPersonalization = 3;
             MaxVocabularyActors = 500;
@@ -42,9 +42,11 @@ namespace Jellyfin.Plugin.LocalRecs.Configuration
         public double FavoriteBoost { get; set; }
 
         /// <summary>
-        /// Gets or sets the boost multiplier for rewatched items.
+        /// Gets or sets the amplification factor for recently watched items.
+        /// A just-watched item (decay=1) receives weight × (1 + RecentWatchBoost).
+        /// Set to 0 to disable; default is 1.0.
         /// </summary>
-        public double RewatchBoost { get; set; }
+        public double RecentWatchBoost { get; set; }
 
         /// <summary>
         /// Gets or sets the recency decay half-life in days.
@@ -107,9 +109,9 @@ namespace Jellyfin.Plugin.LocalRecs.Configuration
                 errors.Add("FavoriteBoost must be non-negative");
             }
 
-            if (RewatchBoost < 0)
+            if (RecentWatchBoost < 0)
             {
-                errors.Add("RewatchBoost must be non-negative");
+                errors.Add("RecentWatchBoost must be non-negative");
             }
 
             if (RecencyDecayHalfLifeDays <= 0)

--- a/Jellyfin.Plugin.LocalRecs/Configuration/configPage.html
+++ b/Jellyfin.Plugin.LocalRecs/Configuration/configPage.html
@@ -62,9 +62,9 @@
                         </div>
                         
                         <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="rewatchBoost">Rewatch Boost:</label>
-                            <input is="emby-input" type="number" id="rewatchBoost" name="rewatchBoost" min="1.0" max="5.0" step="0.1" />
-                            <div class="fieldDescription">Multiplier for rewatched items (default: 1.5)</div>
+                            <label class="inputLabel inputLabelUnfocused" for="recentWatchBoost">Recent Watch Emphasis:</label>
+                            <input is="emby-input" type="number" id="recentWatchBoost" name="recentWatchBoost" min="0" max="5.0" step="0.1" />
+                            <div class="fieldDescription">How much more a recently watched item shapes your taste profile compared to older watches. 0 = no emphasis, 1 = just-watched items get 2× weight (default: 1.0)</div>
                         </div>
                         
                         <div class="inputContainer">
@@ -429,7 +429,7 @@
                             page.querySelector('#tvRecommendationCount').value = config.TvRecommendationCount || 25;
                             page.querySelector('#minWatchedItems').value = config.MinWatchedItemsForPersonalization || 3;
                             page.querySelector('#favoriteBoost').value = config.FavoriteBoost || 2.0;
-                            page.querySelector('#rewatchBoost').value = config.RewatchBoost || 1.5;
+                            page.querySelector('#recentWatchBoost').value = config.RecentWatchBoost !== undefined ? config.RecentWatchBoost : 1.0;
                             page.querySelector('#recencyDecayHalfLife').value = config.RecencyDecayHalfLifeDays || 365;
                             page.querySelector('#maxVocabularyActors').value = config.MaxVocabularyActors || 500;
                             page.querySelector('#maxVocabularyDirectors').value = config.MaxVocabularyDirectors || 0;
@@ -468,7 +468,7 @@
                             config.TvRecommendationCount = parseInt(page.querySelector('#tvRecommendationCount').value);
                             config.MinWatchedItemsForPersonalization = parseInt(page.querySelector('#minWatchedItems').value);
                             config.FavoriteBoost = parseFloat(page.querySelector('#favoriteBoost').value);
-                            config.RewatchBoost = parseFloat(page.querySelector('#rewatchBoost').value);
+                            config.RecentWatchBoost = parseFloat(page.querySelector('#recentWatchBoost').value);
                             config.RecencyDecayHalfLifeDays = parseFloat(page.querySelector('#recencyDecayHalfLife').value);
                             config.MaxVocabularyActors = parseInt(page.querySelector('#maxVocabularyActors').value);
                             config.MaxVocabularyDirectors = parseInt(page.querySelector('#maxVocabularyDirectors').value);

--- a/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
@@ -145,23 +145,30 @@ namespace Jellyfin.Plugin.LocalRecs.Services
                     continue;
                 }
 
-                // For series, userData.Played is unreliable - it only becomes true when ALL
-                // episodes are watched. Instead, check for any watched episodes to include
-                // series the user has actually engaged with in the taste profile.
+                // For series, userData.Played is unreliable — it only becomes true when ALL
+                // episodes are watched. Use the most recently watched episode's date instead.
+                DateTime lastPlayedDate;
                 if (item is Series series)
                 {
-                    if (!HasAnyWatchedEpisodes(series, user))
+                    var seriesLastPlayed = GetLastWatchedEpisodeDate(series, user);
+                    if (seriesLastPlayed == null)
                     {
                         continue;
                     }
+
+                    lastPlayedDate = seriesLastPlayed.Value;
                 }
                 else if (!userData.Played)
                 {
                     // For movies, Played = true means the movie was completed.
                     continue;
                 }
+                else
+                {
+                    lastPlayedDate = userData.LastPlayedDate ?? DateTime.UtcNow;
+                }
 
-                var record = new WatchRecord(itemId, userId, userData.LastPlayedDate ?? DateTime.UtcNow)
+                var record = new WatchRecord(itemId, userId, lastPlayedDate)
                 {
                     IsFavorite = userData.IsFavorite,
                     PlayCount = userData.PlayCount > 0 ? userData.PlayCount : 1,
@@ -176,20 +183,28 @@ namespace Jellyfin.Plugin.LocalRecs.Services
         }
 
         /// <summary>
-        /// Checks if a series has any watched episodes.
+        /// Returns the most recent LastPlayedDate across watched episodes of a series,
+        /// or null if no episodes have been watched.
         /// </summary>
-        private bool HasAnyWatchedEpisodes(Series series, Jellyfin.Database.Implementations.Entities.User user)
+        private DateTime? GetLastWatchedEpisodeDate(Series series, Jellyfin.Database.Implementations.Entities.User user)
         {
-            var watchedEpisodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            var result = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 AncestorIds = new[] { series.Id },
                 IsPlayed = true,
-                Limit = 1,
-                Recursive = true
+                Recursive = true,
+                OrderBy = new[] { (ItemSortBy.DatePlayed, Jellyfin.Database.Implementations.Enums.SortOrder.Descending) },
+                Limit = 1
             });
 
-            return watchedEpisodes.Count > 0;
+            if (result.Count == 0)
+            {
+                return null;
+            }
+
+            var epData = _userDataManager.GetUserData(user, result[0]);
+            return epData?.LastPlayedDate ?? DateTime.UtcNow;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
@@ -247,8 +247,7 @@ namespace Jellyfin.Plugin.LocalRecs.Services
                     config.RecencyDecayHalfLifeDays,
                     record.IsFavorite,
                     (float)config.FavoriteBoost,
-                    Math.Max(1, record.PlayCount),
-                    (float)config.RewatchBoost);
+                    (float)config.RecentWatchBoost);
 
                 // Accumulate weighted vectors
                 for (int i = 0; i < dimension; i++)

--- a/Jellyfin.Plugin.LocalRecs/Utilities/WeightCalculator.cs
+++ b/Jellyfin.Plugin.LocalRecs/Utilities/WeightCalculator.cs
@@ -3,7 +3,7 @@ using System;
 namespace Jellyfin.Plugin.LocalRecs.Utilities
 {
     /// <summary>
-    /// Pure functions for computing weights (recency decay, favorite boost, rewatch boost).
+    /// Pure functions for computing weights (recency decay, favorite boost, recent watch boost).
     /// </summary>
     public static class WeightCalculator
     {
@@ -55,62 +55,50 @@ namespace Jellyfin.Plugin.LocalRecs.Utilities
         }
 
         /// <summary>
-        /// Applies rewatch boost using logarithmic scaling.
-        /// Boost = base_weight × (1 + log(play_count, rewatch_base)).
+        /// Applies recent watch boost using decay-squared amplification.
+        /// Weight = decay × (1 + recentWatchBoost × decay).
+        /// Items watched recently (decay near 1) receive up to (1 + recentWatchBoost)× weight.
+        /// Items watched long ago (decay near 0) receive near-zero additional boost.
         /// </summary>
-        /// <param name="baseWeight">The base weight.</param>
-        /// <param name="playCount">Number of times the item was played.</param>
-        /// <param name="rewatchBase">Base for logarithmic scaling (default 1.5).</param>
+        /// <param name="decay">Recency decay value between 0 and 1.</param>
+        /// <param name="recentWatchBoost">Boost multiplier for recently watched items (0 = no boost).</param>
         /// <returns>Boosted weight.</returns>
-        /// <exception cref="ArgumentException">Thrown when baseWeight is negative, playCount is less than 1, or rewatchBase is less than or equal to 1.</exception>
-        public static float ApplyRewatchBoost(float baseWeight, int playCount, float rewatchBase = 1.5f)
+        /// <exception cref="ArgumentException">Thrown when decay is outside [0,1] or recentWatchBoost is negative.</exception>
+        public static float ApplyRecentWatchBoost(float decay, float recentWatchBoost)
         {
-            if (baseWeight < 0)
+            if (decay < 0 || decay > 1)
             {
-                throw new ArgumentException("Base weight cannot be negative", nameof(baseWeight));
+                throw new ArgumentException("Decay must be between 0 and 1", nameof(decay));
             }
 
-            if (playCount < 1)
+            if (recentWatchBoost < 0)
             {
-                throw new ArgumentException("Play count must be at least 1", nameof(playCount));
+                throw new ArgumentException("Recent watch boost cannot be negative", nameof(recentWatchBoost));
             }
 
-            if (rewatchBase <= 1)
-            {
-                throw new ArgumentException("Rewatch base must be greater than 1", nameof(rewatchBase));
-            }
-
-            if (playCount == 1)
-            {
-                return baseWeight; // No boost for single watch
-            }
-
-            // Logarithmic scaling: 1 + log_base(play_count)
-            float boost = 1.0f + (float)Math.Log(playCount, rewatchBase);
-            return baseWeight * boost;
+            return decay * (1.0f + (recentWatchBoost * decay));
         }
 
         /// <summary>
         /// Computes the combined weight for a watch record.
+        /// Formula: decay × (1 + recentWatchBoost × decay) × favoriteBoost.
         /// </summary>
         /// <param name="daysSince">Days since last watched.</param>
         /// <param name="halfLifeDays">Recency decay half-life.</param>
         /// <param name="isFavorite">Whether the item is favorite.</param>
         /// <param name="favoriteBoost">Favorite boost multiplier.</param>
-        /// <param name="playCount">Number of times played.</param>
-        /// <param name="rewatchBase">Rewatch logarithmic base.</param>
+        /// <param name="recentWatchBoost">Amplification factor for recently watched items.</param>
         /// <returns>Combined weight.</returns>
         public static float ComputeCombinedWeight(
             double daysSince,
             double halfLifeDays,
             bool isFavorite,
             float favoriteBoost,
-            int playCount,
-            float rewatchBase = 1.5f)
+            float recentWatchBoost)
         {
-            float weight = ExponentialDecay(daysSince, halfLifeDays);
+            float decay = ExponentialDecay(daysSince, halfLifeDays);
+            float weight = ApplyRecentWatchBoost(decay, recentWatchBoost);
             weight = ApplyFavoriteBoost(weight, isFavorite, favoriteBoost);
-            weight = ApplyRewatchBoost(weight, playCount, rewatchBase);
             return weight;
         }
     }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Access via: **Dashboard → Plugins → Local Recommendations → Settings**
 
 **Weighting Factors**
 - Favorite boost: 2.0x (configurable)
-- Rewatch boost: 1.5x (configurable)
+- Recent watch emphasis: 1.0 (configurable) — amplifies recently watched items using decay²
 - Recency decay half-life: 365 days (configurable)
 
 **Optional Features**
@@ -120,7 +120,7 @@ Access via: **Dashboard → Plugins → Local Recommendations → Settings**
 
 **Weighting factors:**
 - Favorites (2x boost)
-- Rewatches (1.5x boost)
+- Recent watch emphasis (decay² amplification, default 1.0)
 - Recency decay (365-day half-life)
 - Decade similarity (items from similar time periods)
 - Optional rating proximity (items with similar ratings)


### PR DESCRIPTION
## Problem

The existing `RewatchBoost` uses Jellyfin's `PlayCount` to apply a logarithmic boost to rewatched items. This is unreliable in practice:

- **Every stop/start of a stream increments `PlayCount`** — pausing and resuming a movie across three sessions registers as `PlayCount = 3`, indistinguishable from a genuine re-watch.
- **Series-level `PlayCount` is nearly always 0 or 1** — it only increments when *every* episode in the series has been watched, so most in-progress series never accumulate any meaningful count.

As a result, the rewatch boost adds noise rather than signal, and its behavior is surprising to users who notice frequently-interrupted items ranked higher than genuinely re-watched ones.

## Prerequisite

> **This PR requires #19 (fix TV series `LastPlayedDate`).**
>
> Without that fix, all TV series have `daysSince = 0` (decay = 1.0) regardless of actual watch date, because Jellyfin only sets `LastPlayedDate` on episode items, never on the series itself. The decay-squared formula here only works correctly for TV shows once series dates are read from the most recently watched episode.

## Solution

Replace `ApplyRewatchBoost` with `ApplyRecentWatchBoost` using a **decay-squared amplification formula**:

```
weight = decay × (1 + recentWatchBoost × decay) × favoriteBoost
```

where `decay = 0.5 ^ (daysSince / halfLifeDays)`.

### Why this works as a rewatch substitute

A genuine re-watch **resets `LastPlayedDate` to now**, giving `decay ≈ 1` and maximum boost — without reading `PlayCount` at all. The formula implicitly rewards rewatching through recency.

### Limitations — this is not a perfect replacement

This approach has a known tradeoff: it cannot distinguish between a first watch and a re-watch if the re-watch happened long ago. A movie watched twice — once last year and once last week — will look the same as a movie watched only last week. Conversely, a movie watched only once but recently will receive the same emphasis boost as a re-watched one.

The core bet is that **recency is a better proxy for preference strength than play count in Jellyfin**, given how unreliable the play count data is. If Jellyfin ever exposes a reliable re-watch count (distinct from `PlayCount`), a combined formula could incorporate both signals.

### Why the double decay matters

The `decay²` term amplifies recently watched items disproportionately more than older ones:

| Days since watched | decay | boost=0 | boost=1 | boost=2 |
|---|---|---|---|---|
| 0 (just watched) | 1.0 | 1.0 | **2.0** | 3.0 |
| 183 (half half-life) | ~0.71 | 0.71 | 1.21 | 1.71 |
| 365 (half-life) | 0.5 | 0.5 | 0.75 | 1.0 |
| 730 (two half-lives) | 0.25 | 0.25 | 0.31 | 0.375 |

This is **not equivalent** to simply shortening the half-life. A shorter half-life compresses all history uniformly; `decay²` disproportionately amplifies the fresh end while leaving the base `decay` contribution of older items intact.

Setting `recentWatchBoost = 0` degrades gracefully to pure recency decay (no emphasis boost at all).

## Changes

- **`WeightCalculator.cs`**: Remove `ApplyRewatchBoost`; add `ApplyRecentWatchBoost(float decay, float recentWatchBoost)`; update `ComputeCombinedWeight` (drop `playCount`/`rewatchBase`, add `recentWatchBoost`)
- **`PluginConfiguration.cs`**: Replace `RewatchBoost` (default 1.5) with `RecentWatchBoost` (default 1.0)
- **`configPage.html`**: Replace "Rewatch Boost" field with "Recent Watch Emphasis" (range 0–5, step 0.1)
- **`UserProfileService.cs`**: Pass `config.RecentWatchBoost` instead of `playCount`/`config.RewatchBoost`
- **`README.md`**, **`DESIGN.md`**: Updated weighting factor descriptions
- All tests updated accordingly

## Migration

Users upgrading from a previous version will have `RecentWatchBoost` default to `1.0` on first save (2× weight for items watched today). The previous `RewatchBoost` setting is silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)