### PR TITLE
Fix: config page numeric fields reset to default when saved as 0

### DIFF
--- a/Jellyfin.Plugin.LocalRecs/Configuration/configPage.html
+++ b/Jellyfin.Plugin.LocalRecs/Configuration/configPage.html
@@ -425,17 +425,17 @@
                     
                     ApiClient.getPluginConfiguration(self.pluginId)
                         .then(function(config) {
-                            page.querySelector('#movieRecommendationCount').value = config.MovieRecommendationCount || 25;
-                            page.querySelector('#tvRecommendationCount').value = config.TvRecommendationCount || 25;
-                            page.querySelector('#minWatchedItems').value = config.MinWatchedItemsForPersonalization || 3;
-                            page.querySelector('#favoriteBoost').value = config.FavoriteBoost || 2.0;
-                            page.querySelector('#rewatchBoost').value = config.RewatchBoost || 1.5;
-                            page.querySelector('#recencyDecayHalfLife').value = config.RecencyDecayHalfLifeDays || 365;
-                            page.querySelector('#maxVocabularyActors').value = config.MaxVocabularyActors || 500;
-                            page.querySelector('#maxVocabularyDirectors').value = config.MaxVocabularyDirectors || 0;
-                            page.querySelector('#maxVocabularyTags').value = config.MaxVocabularyTags || 500;
+                            page.querySelector('#movieRecommendationCount').value = config.MovieRecommendationCount !== undefined ? config.MovieRecommendationCount : 25;
+                            page.querySelector('#tvRecommendationCount').value = config.TvRecommendationCount !== undefined ? config.TvRecommendationCount : 25;
+                            page.querySelector('#minWatchedItems').value = config.MinWatchedItemsForPersonalization !== undefined ? config.MinWatchedItemsForPersonalization : 3;
+                            page.querySelector('#favoriteBoost').value = config.FavoriteBoost !== undefined ? config.FavoriteBoost : 2.0;
+                            page.querySelector('#rewatchBoost').value = config.RewatchBoost !== undefined ? config.RewatchBoost : 1.5;
+                            page.querySelector('#recencyDecayHalfLife').value = config.RecencyDecayHalfLifeDays !== undefined ? config.RecencyDecayHalfLifeDays : 365;
+                            page.querySelector('#maxVocabularyActors').value = config.MaxVocabularyActors !== undefined ? config.MaxVocabularyActors : 500;
+                            page.querySelector('#maxVocabularyDirectors').value = config.MaxVocabularyDirectors !== undefined ? config.MaxVocabularyDirectors : 0;
+                            page.querySelector('#maxVocabularyTags').value = config.MaxVocabularyTags !== undefined ? config.MaxVocabularyTags : 500;
                             page.querySelector('#enableRatingProximity').checked = config.EnableRatingProximity || false;
-                            page.querySelector('#ratingProximityWeight').value = config.RatingProximityWeight || 0.2;
+                            page.querySelector('#ratingProximityWeight').value = config.RatingProximityWeight !== undefined ? config.RatingProximityWeight : 0.2;
 
                             self.updateFieldVisibility(page);
                             Dashboard.hideLoadingMsg();


### PR DESCRIPTION
## Summary

- JavaScript's `||` operator treats `0` as falsy, causing numeric config fields to display their hardcoded default instead of the user's saved value of `0`
- Any subsequent save would then silently persist the default, overwriting the setting
- Replaces `config.X || default` with `config.X !== undefined ? config.X : default` for all numeric fields on the config page

## Fields affected

- `MovieRecommendationCount`, `TvRecommendationCount`
- `MinWatchedItemsForPersonalization`
- `FavoriteBoost`, `RewatchBoost`
- `RecencyDecayHalfLifeDays`
- `MaxVocabularyActors`, `MaxVocabularyTags`
- `RatingProximityWeight`

(`MaxVocabularyDirectors` and boolean fields are unaffected — their fallback is already `0`/`false`.)

## Why this is safe

The C# `PluginConfiguration` constructor initialises every property, so Jellyfin's API never returns a field as `undefined`. The `: default` fallback is purely defensive and is never reached in practice — behaviour is identical to before for all non-zero values.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)