### PR TITLE
Remove dead WatchRecord.PlayCount field

### DIFF
--- a/Jellyfin.Plugin.LocalRecs.Tests/Fixtures/TestUserData.cs
+++ b/Jellyfin.Plugin.LocalRecs.Tests/Fixtures/TestUserData.cs
@@ -26,8 +26,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(matrix.Id, userId, now.AddDays(-7))
                 {
-                    IsFavorite = true,
-                    PlayCount = 3
+                    IsFavorite = true
                 });
             }
 
@@ -37,8 +36,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(inception.Id, userId, now.AddDays(-14))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -48,8 +46,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(bladeRunner.Id, userId, now.AddDays(-21))
                 {
-                    IsFavorite = true,
-                    PlayCount = 2
+                    IsFavorite = true
                 });
             }
 
@@ -59,8 +56,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(interstellar.Id, userId, now.AddDays(-90))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -70,8 +66,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(alien.Id, userId, now.AddDays(-180))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -95,8 +90,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(godfather.Id, userId, now.AddDays(-10))
                 {
-                    IsFavorite = true,
-                    PlayCount = 5
+                    IsFavorite = true
                 });
             }
 
@@ -106,8 +100,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(shawshank.Id, userId, now.AddDays(-20))
                 {
-                    IsFavorite = true,
-                    PlayCount = 3
+                    IsFavorite = true
                 });
             }
 
@@ -117,8 +110,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(darkKnight.Id, userId, now.AddDays(-30))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -142,8 +134,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(toyStory.Id, userId, now.AddDays(-5))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -152,8 +143,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
             {
                 records.Add(new WatchRecord(groundhogDay.Id, userId, now.AddDays(-10))
                 {
-                    IsFavorite = false,
-                    PlayCount = 1
+                    IsFavorite = false
                 });
             }
 
@@ -181,8 +171,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
                 {
                     records.Add(new WatchRecord(film.Id, userId, now.AddDays(-5 - (i * 8)))
                     {
-                        IsFavorite = true,
-                        PlayCount = 2 + (i % 3)
+                        IsFavorite = true
                     });
                 }
             }
@@ -211,8 +200,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
                 {
                     records.Add(new WatchRecord(film.Id, userId, now.AddDays(-i))
                     {
-                        IsFavorite = false,
-                        PlayCount = 1
+                        IsFavorite = false
                     });
                 }
             }
@@ -241,8 +229,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
                 {
                     records.Add(new WatchRecord(film.Id, userId, now.AddDays(-365 - (i * 30)))
                     {
-                        IsFavorite = false,
-                        PlayCount = 1
+                        IsFavorite = false
                     });
                 }
             }
@@ -271,8 +258,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
                 {
                     records.Add(new WatchRecord(series.Id, userId, now.AddDays(-10 - (i * 15)))
                     {
-                        IsFavorite = seriesNames[i] == "Breaking Bad",
-                        PlayCount = 1 + (i % 2)
+                        IsFavorite = seriesNames[i] == "Breaking Bad"
                     });
                 }
             }
@@ -308,8 +294,7 @@ namespace Jellyfin.Plugin.LocalRecs.Tests.Fixtures
                 {
                     records.Add(new WatchRecord(film.Id, userId, now.AddDays(-15 - (i * 5)))
                     {
-                        IsFavorite = i == 0, // Only first one is favorite
-                        PlayCount = 1
+                        IsFavorite = i == 0 // Only first one is favorite
                     });
                 }
             }

--- a/Jellyfin.Plugin.LocalRecs/Models/WatchRecord.cs
+++ b/Jellyfin.Plugin.LocalRecs/Models/WatchRecord.cs
@@ -41,11 +41,6 @@ namespace Jellyfin.Plugin.LocalRecs.Models
         public bool IsFavorite { get; set; }
 
         /// <summary>
-        /// Gets or sets the play count.
-        /// </summary>
-        public int PlayCount { get; set; }
-
-        /// <summary>
         /// Gets or sets the community rating (0-10 scale) of the item, if available.
         /// </summary>
         public float? CommunityRating { get; set; }

--- a/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.LocalRecs/Services/UserProfileService.cs
@@ -171,7 +171,6 @@ namespace Jellyfin.Plugin.LocalRecs.Services
                 var record = new WatchRecord(itemId, userId, lastPlayedDate)
                 {
                     IsFavorite = userData.IsFavorite,
-                    PlayCount = userData.PlayCount > 0 ? userData.PlayCount : 1,
                     CommunityRating = item.CommunityRating,
                     CriticRating = item.CriticRating
                 };


### PR DESCRIPTION
## Summary

Closes #25.

After #20 replaced the `PlayCount`-based rewatch boost with the recency-driven `RecentWatchBoost`, `WatchRecord.PlayCount` became dead: it was still populated in `UserProfileService.GetWatchRecords` but never read by any weighting logic (`ComputeTasteVector` reads `IsFavorite`, `LastPlayedDate`, `CommunityRating`, and `CriticRating` — not `PlayCount`).

## Changes

- Remove the `PlayCount` property from the `WatchRecord` model.
- Drop its population site in `UserProfileService.GetWatchRecords`.
- Strip the now-invalid `PlayCount` initializers from the `TestUserData` fixtures' `WatchRecord` builders.

## Left intact (intentionally)

- `UserItemData.PlayCount` in `VirtualLibrary/PlayStatusSyncService.cs` — that's Jellyfin's own property used for play-state sync, unrelated to the recommendation weighting.
- The tuple-format fixture methods (`CreateSciFiFanHistory`, `CreateDramaFanHistory`) carry a `PlayCount` tuple field that feeds `UserItemData.PlayCount` — also unrelated and untouched.

## Note (out of scope)

While stripping the initializers I noticed the seven `WatchRecord`-returning fixture methods (`CreateSciFiFan`, `CreateDramaFan`, `CreateColdStartUser`, `CreateNolanFan`, `CreateRecentWatcher`, `CreateOldWatcher`, `CreateSeriesWatcher`, `CreateDiverseWatcher`) appear to be unused dead code — only the tuple-format `CreateDramaFanHistory` is referenced by a test. Left them in place to keep this PR focused; happy to remove in a follow-up.

## Verification

- `dotnet test --configuration Release`: **234 passed, 0 failed, 6 skipped**, 0 build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
