### PR TITLE
Release v0.6.1: Jellyfin 10.11.9+ compatibility and recommendation fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,5 +60,5 @@ body:
           required: true
         - label: I have sanitized all personal information from logs and descriptions
           required: true
-        - label: I am using a supported version of Jellyfin (10.11.5+)
+        - label: I am using a supported version of Jellyfin (10.11.9+)
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-30
+
+### Fixed
+
+- **Jellyfin 10.11.9+ compatibility (#17, fixes #21)**: the recommendation refresh, benchmark, setup, and play-status sync tasks no longer crash with `MissingMethodException: IUserManager.get_Users()`. Jellyfin 10.11.9 removed the `IUserManager.Users` property as part of its EFCore refactor ([jellyfin#15368](https://github.com/jellyfin/jellyfin/pull/15368)); all six call sites now use `GetUsers()`. **This release requires Jellyfin 10.11.9 or newer** (see Upgrade Notes).
+- **TV series recency (#19)**: a series is now weighted by the date of its most recently watched episode. Previously every watched series was treated as watched *today* — Jellyfin never sets `LastPlayedDate` on the series item itself — which inflated TV influence on the taste profile regardless of when it was actually watched.
+- **Config page numeric fields (#22)**: numeric settings saved as `0` no longer silently revert to their hardcoded defaults on the next page load (JavaScript `||` treated `0` as falsy).
+
+### Changed
+
+- **Recent-watch emphasis replaces rewatch boost (#20)**: the play-count–based rewatch boost is replaced by a recency-driven `decay²` amplification (`weight = decay × (1 + RecentWatchBoost × decay)`). Jellyfin's `PlayCount` increments on every stop/start of a stream and is near-useless at the series level, so recency is now used as the preference-strength proxy (a genuine re-watch resets recency anyway). The `RewatchBoost` setting (default 1.5) is replaced by **`RecentWatchBoost`** (default 1.0); the old value is dropped on first save. Set `RecentWatchBoost = 0` to disable the emphasis entirely.
+
+### Internal
+
+- Removed the now-unused `WatchRecord.PlayCount` field (#25) and added regression tests covering the TV-series recency path (#24).
+
+### Upgrade Notes
+
+- **Requires Jellyfin 10.11.9.0 or newer.** This release targets ABI `10.11.9.0` and is **not** compatible with 10.11.0–10.11.8 (the `GetUsers()` API does not exist there). Jellyfin's plugin catalogue will only offer this update to servers running 10.11.9+; servers on older 10.11.x builds should remain on 0.6.0 until they update Jellyfin.
+- Recommendation ranking will shift on upgrade: the move to recency-based emphasis (and the series-recency fix) changes how watch history is weighted. Recommendations regenerate on the next scheduled refresh.
+
+### Credits
+
+- Huge thanks to [@PascalGodin](https://github.com/PascalGodin), who contributed the bulk of this release — the 10.11.9 compatibility fix (#17), the TV-series recency fix (#19), the recent-watch emphasis redesign (#20), and the config-page zero-value fix (#22).
+
 ## [0.6.0] - 2026-04-15
 
 ### Changed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,7 @@
 # Local Recommendations - Design Document
 
 **Version:** 0.1.0 Beta  
-**Target:** Jellyfin 10.11.5, .NET 9.0  
+**Target:** Jellyfin 10.11.9, .NET 9.0  
 **License:** GPLv3
 
 ## Overview

--- a/Jellyfin.Plugin.LocalRecs/Jellyfin.Plugin.LocalRecs.csproj
+++ b/Jellyfin.Plugin.LocalRecs/Jellyfin.Plugin.LocalRecs.csproj
@@ -8,9 +8,9 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>0.6.0.0</Version>
-        <AssemblyVersion>0.6.0.0</AssemblyVersion>
-        <FileVersion>0.6.0.0</FileVersion>
+        <Version>0.6.1.0</Version>
+        <AssemblyVersion>0.6.1.0</AssemblyVersion>
+        <FileVersion>0.6.1.0</FileVersion>
         <CodeAnalysisRuleSet>$(SolutionDir)\jellyfin.ruleset</CodeAnalysisRuleSet>
         <NoWarn>SA1633,SA1200,SA1101,SA1309,SA1413</NoWarn>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Please report any issues or feedback on [GitHub Issues](https://github.com/rdpha
 
 ## Requirements
 
-- **Jellyfin Server:** 10.11.5+
+- **Jellyfin Server:** 10.11.9+
 - **.NET Runtime:** 9.0
-- **Target ABI:** 10.11.0.0
+- **Target ABI:** 10.11.9.0
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "0.6.1.0",
+        "changelog": "Jellyfin 10.11.9+ compatibility and recommendation-quality fixes\n- Fixes MissingMethodException crash on Jellyfin 10.11.9/10.11.10 (#17, fixes #21): all IUserManager.Users call sites now use GetUsers()\n- TV series now weighted by most recently watched episode date instead of always 'today' (#19)\n- Replaced play-count rewatch boost with recency-driven Recent Watch Emphasis using decay-squared amplification (#20); the RewatchBoost setting becomes RecentWatchBoost (default 1.0)\n- Config page numeric fields saved as 0 no longer revert to defaults (#22)\n- REQUIRES Jellyfin 10.11.9 or newer",
+        "targetAbi": "10.11.9.0",
+        "sourceUrl": "https://github.com/rdpharr/jellyfin-plugin-localrecs/releases/download/v0.6.1/jellyfin-plugin-localrecs-v0.6.1.zip",
+        "checksum": "564672f997c9cd6da4f07efeae2107bc",
+        "timestamp": "2026-05-30T00:00:00Z"
+      },
+      {
         "version": "0.6.0.0",
         "changelog": "Migrate from .strm files to filesystem symlinks (#13)\n- Fixes transcoded playback on Jellyfin 10.11.7+ (GHSA-j2hf-x4q5-47j3)\n- Symlinks preserve source extensions; media pipeline treats them as regular files\n- Artwork symlinked from source folder (propagates custom posters automatically)\n- Trailer discovery delegated to Jellyfin's native scanner\n- Removed ImageSyncService and EnableImageSync/SyncBackdrops settings\n- WINDOWS: requires Administrator or Developer Mode enabled for symlink creation",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Release v0.6.1

Bumps the plugin to **0.6.1.0** and **`targetAbi` 10.11.9.0**, and rolls up the fixes merged since v0.6.0.

### Included
- **#17** — Jellyfin 10.11.9+ compatibility: `IUserManager.Users` → `GetUsers()` (resolves the `MissingMethodException` crash from #21)
- **#19** — TV series recency uses the most recently watched episode's date
- **#20** — recency-driven "Recent Watch Emphasis" (decay²) replaces the play-count rewatch boost (`RewatchBoost` → `RecentWatchBoost`)
- **#22** — config-page numeric fields saved as `0` no longer revert to defaults
- **#24 / #25** — series-recency regression tests added; dead `WatchRecord.PlayCount` removed

### Release metadata
- `manifest.json`: new `0.6.1.0` entry, `targetAbi` `10.11.9.0`, checksum `564672f997c9cd6da4f07efeae2107bc`, sourceUrl → `v0.6.1` release asset
- `CHANGELOG.md`, `README.md`, `DESIGN.md`, bug-report template updated to the **10.11.9** minimum

### Credits
Big thanks to **@PascalGodin**, who contributed the bulk of this release (#17, #19, #20, #22). 🙏

### Verified
- Release build: 0 errors; `dotnet test`: 236 passed / 0 failed / 6 skipped
- Test-deployed the build to a live Jellyfin **10.11.10** server: plugin loads Active and the **Refresh** task (previously failing with the #21 crash) now completes cleanly.

Closes #21
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
